### PR TITLE
[feat] 좌석 선택 시 매크로 방지 문자열 구현

### DIFF
--- a/src/main/java/com/fifo/ticketing/global/capcha/CaptchaController.kt
+++ b/src/main/java/com/fifo/ticketing/global/capcha/CaptchaController.kt
@@ -44,23 +44,7 @@ class CaptchaController(
         return ResponseEntity.ok("올바른 입력입니다.")
     }
 
-    private fun generateRandomText(): String {
-        val chars = "ABCDEFGHJKLMNPQRSTUVWXYZ123456789"
-        return (1..6).map { chars.random() }.joinToString("")
-    }
 
-    private fun createCaptchaImage(text: String): ByteArray{ //캡차 이미지 바이트 배열로 생성
-        val img = BufferedImage(150, 50, BufferedImage.TYPE_INT_RGB)
-        val g = img.createGraphics()
-        g.color = Color.white
-        g.fillRect(0,0, 150, 50)
-        g.color = Color.black
-        g.font = Font("Arial", Font.BOLD, 32)
-        g.drawString(text, 20, 35)
-        g.dispose()
 
-        val baos = ByteArrayOutputStream()
-        ImageIO.write(img, "png", baos)
-        return baos.toByteArray()
-    }
+
 }

--- a/src/main/java/com/fifo/ticketing/global/capcha/CaptchaController.kt
+++ b/src/main/java/com/fifo/ticketing/global/capcha/CaptchaController.kt
@@ -1,0 +1,66 @@
+package com.fifo.ticketing.global.capcha
+
+import com.fifo.ticketing.global.capcha.dto.CaptchaResponse
+import com.fifo.ticketing.global.capcha.dto.CaptchaVerifyRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.awt.Color
+import java.awt.Font
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import javax.imageio.ImageIO
+
+@RestController
+@RequestMapping("/api/captcha")
+class CaptchaController(
+    private val captchaStorage: CaptchaStore
+) {
+
+
+    @GetMapping
+    fun generateCaptcha(): CaptchaResponse{
+        val randText = generateRandomText()
+        val id = UUID.randomUUID().toString()
+
+        captchaStorage[id] = randText;
+
+        val image = createCaptchaImage(randText)
+        val imageBase64 = Base64.getEncoder().encodeToString(image)
+
+        return CaptchaResponse(id, "data:image/png;base64,$imageBase64")
+    }
+    @PostMapping("/verify")
+    fun verifyCaptcha(@RequestBody req: CaptchaVerifyRequest) : ResponseEntity<String> {
+        val expected = captchaStorage[req.captchaId] ?: return ResponseEntity.status(403).body("유효 시간이 만료되었습니다.")
+        if(expected != req.input) return ResponseEntity.status(403).body("잘못된 인증 번호입니다.")
+
+        captchaStorage.remove(req.captchaId)
+        return ResponseEntity.ok("올바른 입력입니다.")
+    }
+
+    private fun generateRandomText(): String {
+        val chars = "ABCDEFGHJKLMNPQRSTUVWXYZ123456789"
+        return (1..6).map { chars.random() }.joinToString("")
+    }
+
+    private fun createCaptchaImage(text: String): ByteArray{ //캡차 이미지 바이트 배열로 생성
+        val img = BufferedImage(150, 50, BufferedImage.TYPE_INT_RGB)
+        val g = img.createGraphics()
+        g.color = Color.white
+        g.fillRect(0,0, 150, 50)
+        g.color = Color.black
+        g.font = Font("Arial", Font.BOLD, 32)
+        g.drawString(text, 20, 35)
+        g.dispose()
+
+        val baos = ByteArrayOutputStream()
+        ImageIO.write(img, "png", baos)
+        return baos.toByteArray()
+    }
+}

--- a/src/main/java/com/fifo/ticketing/global/capcha/CaptchaController.kt
+++ b/src/main/java/com/fifo/ticketing/global/capcha/CaptchaController.kt
@@ -3,18 +3,8 @@ package com.fifo.ticketing.global.capcha
 import com.fifo.ticketing.global.capcha.dto.CaptchaResponse
 import com.fifo.ticketing.global.capcha.dto.CaptchaVerifyRequest
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
-import java.awt.Color
-import java.awt.Font
-import java.awt.image.BufferedImage
-import java.io.ByteArrayOutputStream
+import org.springframework.web.bind.annotation.*
 import java.util.*
-import java.util.concurrent.ConcurrentHashMap
-import javax.imageio.ImageIO
 
 @RestController
 @RequestMapping("/api/captcha")
@@ -24,7 +14,7 @@ class CaptchaController(
 
 
     @GetMapping
-    fun generateCaptcha(): CaptchaResponse{
+    fun generateCaptcha(): CaptchaResponse {
         val randText = generateRandomText()
         val id = UUID.randomUUID().toString()
 
@@ -35,16 +25,16 @@ class CaptchaController(
 
         return CaptchaResponse(id, "data:image/png;base64,$imageBase64")
     }
+
     @PostMapping("/verify")
-    fun verifyCaptcha(@RequestBody req: CaptchaVerifyRequest) : ResponseEntity<String> {
-        val expected = captchaStorage[req.captchaId] ?: return ResponseEntity.status(403).body("유효 시간이 만료되었습니다.")
-        if(expected != req.input) return ResponseEntity.status(403).body("잘못된 인증 번호입니다.")
+    fun verifyCaptcha(@RequestBody req: CaptchaVerifyRequest): ResponseEntity<String> {
+        val expected = captchaStorage[req.captchaId] ?: return ResponseEntity.status(403)
+            .body("유효 시간이 만료되었습니다.")
+        if (expected != req.input) return ResponseEntity.status(403).body("잘못된 인증 번호입니다.")
 
         captchaStorage.remove(req.captchaId)
         return ResponseEntity.ok("올바른 입력입니다.")
     }
-
-
 
 
 }

--- a/src/main/java/com/fifo/ticketing/global/capcha/CaptchaController.kt
+++ b/src/main/java/com/fifo/ticketing/global/capcha/CaptchaController.kt
@@ -15,12 +15,12 @@ class CaptchaController(
 
     @GetMapping
     fun generateCaptcha(): CaptchaResponse {
-        val randText = generateRandomText()
+        val randomText = generateRandomText()
         val id = UUID.randomUUID().toString()
 
-        captchaStorage[id] = randText;
+        captchaStorage[id] = randomText;
 
-        val image = createCaptchaImage(randText)
+        val image = createCaptchaImage(randomText)
         val imageBase64 = Base64.getEncoder().encodeToString(image)
 
         return CaptchaResponse(id, "data:image/png;base64,$imageBase64")

--- a/src/main/java/com/fifo/ticketing/global/capcha/CaptchaService.kt
+++ b/src/main/java/com/fifo/ticketing/global/capcha/CaptchaService.kt
@@ -1,0 +1,21 @@
+package com.fifo.ticketing.global.capcha
+
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class CaptchaStore {
+    val storage = ConcurrentHashMap<String, String>() // 임시 저장 위해
+
+    operator fun set(id: String, value: String) {
+        storage[id] = value
+    }
+
+    operator fun get(id: String): String? {
+        return storage[id]
+    }
+
+    fun remove(id: String) {
+        storage.remove(id)
+    }
+}

--- a/src/main/java/com/fifo/ticketing/global/capcha/CaptchaService.kt
+++ b/src/main/java/com/fifo/ticketing/global/capcha/CaptchaService.kt
@@ -25,11 +25,11 @@ class CaptchaStore {
     }
 }
 
-fun createCaptchaImage(text: String): ByteArray{ //캡차 이미지 바이트 배열로 생성
+fun createCaptchaImage(text: String): ByteArray { //캡차 이미지 바이트 배열로 생성
     val img = BufferedImage(150, 50, BufferedImage.TYPE_INT_RGB)
     val g = img.createGraphics()
     g.color = Color.white
-    g.fillRect(0,0, 150, 50)
+    g.fillRect(0, 0, 150, 50)
     g.color = Color.black
     g.font = Font("Arial", Font.BOLD, 32)
     g.drawString(text, 20, 35)

--- a/src/main/java/com/fifo/ticketing/global/capcha/CaptchaService.kt
+++ b/src/main/java/com/fifo/ticketing/global/capcha/CaptchaService.kt
@@ -1,7 +1,12 @@
 package com.fifo.ticketing.global.capcha
 
 import org.springframework.stereotype.Component
+import java.awt.Color
+import java.awt.Font
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
 import java.util.concurrent.ConcurrentHashMap
+import javax.imageio.ImageIO
 
 @Component
 class CaptchaStore {
@@ -18,4 +23,24 @@ class CaptchaStore {
     fun remove(id: String) {
         storage.remove(id)
     }
+}
+
+fun createCaptchaImage(text: String): ByteArray{ //캡차 이미지 바이트 배열로 생성
+    val img = BufferedImage(150, 50, BufferedImage.TYPE_INT_RGB)
+    val g = img.createGraphics()
+    g.color = Color.white
+    g.fillRect(0,0, 150, 50)
+    g.color = Color.black
+    g.font = Font("Arial", Font.BOLD, 32)
+    g.drawString(text, 20, 35)
+    g.dispose()
+
+    val baos = ByteArrayOutputStream()
+    ImageIO.write(img, "png", baos)
+    return baos.toByteArray()
+}
+
+fun generateRandomText(): String {
+    val chars = "ABCDEFGHJKLMNPQRSTUVWXYZ123456789"
+    return (1..6).map { chars.random() }.joinToString("")
 }

--- a/src/main/java/com/fifo/ticketing/global/capcha/dto/CaptchaDto.kt
+++ b/src/main/java/com/fifo/ticketing/global/capcha/dto/CaptchaDto.kt
@@ -1,0 +1,11 @@
+package com.fifo.ticketing.global.capcha.dto
+
+data class CaptchaResponse(
+    val captchaId: String,
+    val image: String
+)
+
+data class CaptchaVerifyRequest(
+    val captchaId: String,
+    val input: String
+)

--- a/src/main/resources/templates/performance/detail.html
+++ b/src/main/resources/templates/performance/detail.html
@@ -83,7 +83,7 @@
     <h2 class="text-lg font-semibold mb-4">자동입력 방지 확인</h2>
     <img id="captchaImage" src="" alt="captcha" class="mx-auto mb-3"/>
     <input type="text" id="captchaInput" placeholder="위에 보이는 문자를 입력하세요"
-      class="border px-3 py-1 w-full rounded mb-3"/>
+           class="border px-3 py-1 w-full rounded mb-3"/>
     <input type="hidden" id="captchaId"/>
     <div class="flex justify-between gap-2">
       <button id="captchaConfirmBtn"
@@ -137,9 +137,11 @@
             class="w-full bg-tickethub text-white py-2 rounded hover:bg-tickethub-dark">좌석 선택
     </button>
 
-    <div th:unless="${performanceDetail.performanceStatus}" class="w-full bg-gray-200 text-gray-700 py-2 px-4 rounded text-center">
-      예매는<br />
-      <span th:text="${#temporals.format(performanceDetail.reservationStartTime, 'yyyy년 MM월 dd일 HH시')}"></span><br />
+    <div th:unless="${performanceDetail.performanceStatus}"
+         class="w-full bg-gray-200 text-gray-700 py-2 px-4 rounded text-center">
+      예매는<br/>
+      <span
+          th:text="${#temporals.format(performanceDetail.reservationStartTime, 'yyyy년 MM월 dd일 HH시')}"></span><br/>
       부터 가능합니다.
     </div>
 
@@ -206,13 +208,6 @@
   const captchaConfirmBtn = document.getElementById("captchaConfirmBtn");
   const captchaCancelBtn = document.getElementById("captchaCancelBtn");
 
-  // 모달 열기
-  // openModalBtn.addEventListener("click", () => {
-  //   modal.classList.remove("hidden");
-  //   overlay.classList.remove("hidden");
-  //   renderSeats();
-  // });
-
   openModalBtn.addEventListener("click", () => fetchCaptcha());
 
   captchaConfirmBtn.addEventListener("click", () => {
@@ -224,12 +219,12 @@
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({captchaId, input})
     }).then(res => {
-      if(res.ok){
+      if (res.ok) {
         captchaModal.classList.add("hidden");
         modal.classList.remove("hidden");
         overlay.classList.remove("hidden");
         renderSeats();
-      }else{
+      } else {
         res.text().then(msg => {
           alert(msg || "캡차가 틀렸습니다.");
           fetchCaptcha();
@@ -245,7 +240,7 @@
     captchaModal.classList.add("hidden");
   });
 
-  function fetchCaptcha(){
+  function fetchCaptcha() {
     fetch("/api/captcha")
     .then(res => res.json())
     .then(data => {

--- a/src/main/resources/templates/performance/detail.html
+++ b/src/main/resources/templates/performance/detail.html
@@ -76,6 +76,28 @@
     justify-content: flex-start;
   }
 </style>
+
+<div id="captchaModal"
+     class="fixed inset-0 bg-black bg-opacity-50 hidden flex justify-center items-center z-50">
+  <div class="bg-white p-6 rounded shadow max-w-sm w-full text-center">
+    <h2 class="text-lg font-semibold mb-4">자동입력 방지 확인</h2>
+    <img id="captchaImage" src="" alt="captcha" class="mx-auto mb-3"/>
+    <input type="text" id="captchaInput" placeholder="위에 보이는 문자를 입력하세요"
+      class="border px-3 py-1 w-full rounded mb-3"/>
+    <input type="hidden" id="captchaId"/>
+    <div class="flex justify-between gap-2">
+      <button id="captchaConfirmBtn"
+              class="flex-1 bg-tickethub text-white py-2 rounded hover:bg-tickethub-dark">
+        확인
+      </button>
+      <button id="captchaCancelBtn"
+              class="flex-1 bg-gray-400 text-white py-2 rounded hover:bg-gray-500">
+        취소
+      </button>
+    </div>
+  </div>
+</div>
+
 <div
     class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-10 bg-white rounded-lg shadow p-6">
   <!-- 왼쪽: 포스터 -->
@@ -177,12 +199,62 @@
   const modalList = document.getElementById("selected-seat-list-modal");
   const seatsPerRow = 10;
 
+  const captchaModal = document.getElementById("captchaModal")
+  const captchaImage = document.getElementById("captchaImage")
+  const captchaInput = document.getElementById("captchaInput");
+  const captchaIdInput = document.getElementById("captchaId");
+  const captchaConfirmBtn = document.getElementById("captchaConfirmBtn");
+  const captchaCancelBtn = document.getElementById("captchaCancelBtn");
+
   // 모달 열기
-  openModalBtn.addEventListener("click", () => {
-    modal.classList.remove("hidden");
-    overlay.classList.remove("hidden");
-    renderSeats();
+  // openModalBtn.addEventListener("click", () => {
+  //   modal.classList.remove("hidden");
+  //   overlay.classList.remove("hidden");
+  //   renderSeats();
+  // });
+
+  openModalBtn.addEventListener("click", () => fetchCaptcha());
+
+  captchaConfirmBtn.addEventListener("click", () => {
+    const input = captchaInput.value.trim();
+    const captchaId = captchaIdInput.value;
+
+    fetch("/api/captcha/verify", {
+      method: "POST",
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({captchaId, input})
+    }).then(res => {
+      if(res.ok){
+        captchaModal.classList.add("hidden");
+        modal.classList.remove("hidden");
+        overlay.classList.remove("hidden");
+        renderSeats();
+      }else{
+        res.text().then(msg => {
+          alert(msg || "캡차가 틀렸습니다.");
+          fetchCaptcha();
+        });
+      }
+    }).catch(err => {
+      alert("서버 오류가 발생했습니다.");
+      console.error(err);
+    })
+  })
+
+  captchaCancelBtn.addEventListener("click", () => {
+    captchaModal.classList.add("hidden");
   });
+
+  function fetchCaptcha(){
+    fetch("/api/captcha")
+    .then(res => res.json())
+    .then(data => {
+      captchaImage.src = data.image;
+      captchaIdInput.value = data.captchaId;
+      captchaInput.value = "";
+      captchaModal.classList.remove("hidden");
+    })
+  }
 
   // 모달 닫기
   closeModalBtn.addEventListener("click", () => {


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->
#46 

#### 1. (작업 파일)

src/main/resources/templates/performance/detail.html

src/main/java/com/fifo/ticketing/global/capcha/CaptchaController.kt
src/main/java/com/fifo/ticketing/global/capcha/CaptchaService.kt
src/main/java/com/fifo/ticketing/global/capcha/dto/CaptchaDto.kt


#### 2. (작업 내용 요약)

ConcurrentHashMap을 통해 간단한 Captcha 시스템을 구현했습니다.

1. 캡챠 이미지를 BufferedImage를 통해 생성 후
2. 이를 ByteArrayOutputStream으로 메모리에서 바이트 배열로 추출
3. 해당 배열을 Base64 문자열로 인코딩 
4. 클라이언트에서 img 태그를 통해 src에 사용

![image](https://github.com/user-attachments/assets/d5d0f42e-3536-4be8-8791-42cfdb97bcb2)
사용자가 공연에 대해 좌석 선택을 누르면 우선 위와 같이 문자열 입력 창이 뜹니다.
![image](https://github.com/user-attachments/assets/c5018a57-2a04-4b6a-821f-fa0facb332cd)
만약 잘못된 창을 입력한 경우에는 위와 같이 나오게 되며
![image](https://github.com/user-attachments/assets/ebe8694a-f83e-4221-83d2-fea93aad2a13)
올바른 문자 입력 시 좌석 선택 칸으로 이동하게 됩니다.


<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->
![image](https://github.com/user-attachments/assets/d342fe70-670b-4170-95ad-e2fb14a3652e)

- 위의 사진과 같이 현재는 파일이 많지 않아서 굳이 service랑 controller를 폴더로 분리하지 않고 진행했는데 이 부분에 대해서 의견 주시면 감사하겠습니다! 
- 우선 현재는 간단하게 ConcurrentHashMap으로 구현 진행했는데 이 다음 이슈로 Redis + TTL 적용해서 보완 진행하겠습니다.
- 테스트 코드도 같이 추가하겠습니다.

<br/>
