### PR TITLE
[feat] RestExceptionAdvice 구현

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/performance/controller/api/PerformanceApiController.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/controller/api/PerformanceApiController.java
@@ -36,7 +36,7 @@ public class PerformanceApiController {
     public ResponseEntity<?> updatePerformance(
             @PathVariable Long id,
             @RequestPart(value = "file", required = false) MultipartFile file,
-            @RequestPart("request") PerformanceRequestDto request) throws IOException {
+            @RequestPart("request") @Valid PerformanceRequestDto request) throws IOException {
         adminPerformanceService.updatePerformance(id, request, file);
         return ResponseEntity.ok("공연이 수정되었습니다.");
     }

--- a/src/main/java/com/fifo/ticketing/global/exception/ErrorCode.kt
+++ b/src/main/java/com/fifo/ticketing/global/exception/ErrorCode.kt
@@ -33,6 +33,7 @@ enum class ErrorCode(
         ErrorStatus.BAD_REQUEST
     ),
     INVALID_DATETIME_TYPE("DATETIME-002", "날짜 형식이 올바르지 않습니다.", ErrorStatus.BAD_REQUEST),
+    INVALID_DATETIME_RESERVATION("DATETIME-003", "예약 시작 시간은 공연 시작 시간 이전이어야 합니다.", ErrorStatus.BAD_REQUEST),
     EMAIL_ALREADY_REGISTERED_WITH_DIFFERENT_PROVIDER(
         "AUTH-004",
         "이미 가입된 이메일입니다. 일반 로그인 방식으로 로그인 해주세요.",

--- a/src/main/java/com/fifo/ticketing/global/exception/RestExceptionAdvice.kt
+++ b/src/main/java/com/fifo/ticketing/global/exception/RestExceptionAdvice.kt
@@ -34,7 +34,8 @@ class RestExceptionAdvice {
 
 
         val errorCode = when(message) {
-            "날짜 순서가 올바르지 않습니다." -> ErrorCode.INVALID_DATETIME_PERIOD
+            "INVALID_DATETIME_TYPE" -> ErrorCode.INVALID_DATETIME_PERIOD
+            "INVALID_DATETIME_RESERVATION" -> ErrorCode.INVALID_DATETIME_RESERVATION
             else -> ErrorCode.INVALID_DATETIME_TYPE
         }
 

--- a/src/main/java/com/fifo/ticketing/global/exception/RestExceptionAdvice.kt
+++ b/src/main/java/com/fifo/ticketing/global/exception/RestExceptionAdvice.kt
@@ -1,7 +1,57 @@
 package com.fifo.ticketing.global.exception
 
+import com.fifo.ticketing.domain.performance.controller.api.PerformanceApiController
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.slf4j.LoggerFactory
+import org.springframework.core.annotation.AnnotatedElementUtils
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.method.HandlerMethod
 
-@RestControllerAdvice
+
+@RestControllerAdvice(assignableTypes = [PerformanceApiController::class])
 class RestExceptionAdvice {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationException(
+        ex: MethodArgumentNotValidException,
+        handlerMethod: HandlerMethod
+    ): Any {
+        // Class Level Error Handling (현재는 @ValidPerformanceDates에 해당)
+        val classLevelError = ex.bindingResult.globalErrors.firstOrNull()
+        val fieldError = ex.bindingResult.fieldErrors.firstOrNull()
+        val message = when {
+            classLevelError != null -> classLevelError.defaultMessage
+            fieldError != null -> fieldError.defaultMessage
+            else -> "잘못된 요청입니다."
+        }
+
+        log.warn("Validation Error: {}", message)
+
+
+        val errorCode = when(message) {
+            "날짜 순서가 올바르지 않습니다." -> ErrorCode.INVALID_DATETIME_PERIOD
+            else -> ErrorCode.INVALID_DATETIME_TYPE
+        }
+
+        val httpStatus = when (errorCode.errorStatus) {
+            ErrorStatus.NOT_FOUND -> HttpStatus.NOT_FOUND
+            ErrorStatus.CONFLICT -> HttpStatus.CONFLICT
+            ErrorStatus.INTERNAL_SERVER_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR
+            ErrorStatus.ALREADY_EXISTS,
+            ErrorStatus.BAD_REQUEST -> HttpStatus.BAD_REQUEST
+            ErrorStatus.UNAUTHORIZED -> HttpStatus.UNAUTHORIZED
+        }
+
+        val response = ErrorResponse<Nothing>(
+            code = errorCode.code,
+            message = errorCode.message
+        )
+
+        return ResponseEntity.status(httpStatus).body(response)
+    }
 }

--- a/src/main/java/com/fifo/ticketing/global/validation/ValidPerformanceDates.kt
+++ b/src/main/java/com/fifo/ticketing/global/validation/ValidPerformanceDates.kt
@@ -10,6 +10,6 @@ import kotlin.reflect.KClass
 annotation class ValidPerformanceDates(
     val message: String =
         "날짜 순서가 올바르지 않습니다.",
-    val groups: Array<KClass<*>> = [],                // 반드시 포함
-    val payload: Array<KClass<out Payload>> = []      // 반드시
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
 )

--- a/src/main/java/com/fifo/ticketing/global/validation/ValidPerformanceDatesValidator.kt
+++ b/src/main/java/com/fifo/ticketing/global/validation/ValidPerformanceDatesValidator.kt
@@ -14,11 +14,17 @@ class ValidPerformanceDatesValidator :
 
         // startTime < endTime
         if (dto.startTime.isAfter(dto.endTime) || dto.startTime.isEqual(dto.endTime)) {
+            context.disableDefaultConstraintViolation()
+            context.buildConstraintViolationWithTemplate("INVALID_DATETIME_PERIOD")
+                .addConstraintViolation()
             return false
         }
 
         // reservationStartTime <= startTime
         if (dto.reservationStartTime.isAfter(dto.startTime)) {
+            context.disableDefaultConstraintViolation()
+            context.buildConstraintViolationWithTemplate("INVALID_DATETIME_RESERVATION")
+                .addConstraintViolation()
             return false
         }
 


### PR DESCRIPTION
#42 

## ✨ 설명

공연 등록 및 수정시에 시용하는 `PerformanceRequestDto`에 유효성 검사 및 커스텀 어노테이션 적용
공연 시작 시간이 공연 종료 시간보다 이후인 경우에 예외가 발생합니다.

#### 1. (작업 파일)

- PerformanceApiController.java
- RestExceptionAdvice.kt
- ValidPerformanceDates.kt

#### 2. (작업 내용 요약)

- 공연 시작 시간이 공연 종료 시간 보다 이후인 경우

<img width="1604" alt="스크린샷 2025-06-16 09 44 03" src="https://github.com/user-attachments/assets/db533367-fd96-4518-a422-7accb5a353d5" />

<img width="1604" alt="스크린샷 2025-06-16 09 44 01" src="https://github.com/user-attachments/assets/64c45409-ea6f-4661-81ca-2da9d8c8fb26" />

- 예약 시작 시간이 공연 시작 시간 이후인 경우

<img width="1604" alt="스크린샷 2025-06-16 10 18 46" src="https://github.com/user-attachments/assets/40383c49-2fdd-4ab4-93dd-70f432b9dc96" />

<img width="1604" alt="스크린샷 2025-06-16 10 18 49" src="https://github.com/user-attachments/assets/48c4b346-09bf-4e75-8c08-78dcb3ae8feb" />

## 💬 리뷰

우선은 기존의 ExceptionAdvice를 참조하여서 예외처리를 구현하였습니다.
동작 자체는 의도대로 동작하나 불필요한 부분이 존재할 것 같습니다.

<br/>
