### PR TITLE
feat : Like Cotroller 테스트 코드 작성

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/like/entity/LikeCount.kt
+++ b/src/main/java/com/fifo/ticketing/domain/like/entity/LikeCount.kt
@@ -1,6 +1,7 @@
 package com.fifo.ticketing.domain.like.entity
 
 import com.fifo.ticketing.domain.performance.entity.Performance
+import com.fifo.ticketing.global.entity.BaseDateEntity
 import jakarta.persistence.*
 
 
@@ -18,4 +19,4 @@ class LikeCount(
 
     @Column(nullable = false)
     var likeCount: Long,
-)
+) : BaseDateEntity()

--- a/src/test/java/com/fifo/ticketing/domain/like/controller/UserLikeControllerTest.kt
+++ b/src/test/java/com/fifo/ticketing/domain/like/controller/UserLikeControllerTest.kt
@@ -1,0 +1,95 @@
+package com.fifo.ticketing.domain.like.controller
+
+import com.fifo.ticketing.domain.like.dto.LikeRequest
+import com.fifo.ticketing.domain.like.service.LikeService
+import com.fifo.ticketing.domain.user.dto.SessionUser
+import com.fifo.ticketing.domain.user.entity.Role
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+
+@WebMvcTest(UserLikeController::class)
+@ActiveProfiles("ci")
+class UserLikeControllerTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var likeService: LikeService
+
+    @Test
+    @WithMockUser(username = "test", roles = ["USER"])
+    fun `좋아요 요청시 Liked 반환`() {
+        val likeRequest = LikeRequest(1L)
+
+        val sessionUser = SessionUser(
+            id = 1,
+            username = "test",
+            role = Role.USER
+        )
+
+        val session = MockHttpSession().apply {
+            setAttribute("loginUser", sessionUser)  // ✅ 정확한 키
+        }
+
+        given(likeService.toggleLike(1L, likeRequest)).willReturn(true)
+
+        mockMvc.perform(
+            post("/user/like")
+                .session(session)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"performanceId": 1}""")
+            // 세션 주입!
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().string("Liked"))
+    }
+
+
+    @Test
+    @WithMockUser(username = "test", roles = ["USER"])
+    fun `좋아요가 이미 존재하면 Unliked 반환`() {
+        // given
+        val likeRequest = LikeRequest(1L)
+
+        val sessionUser = SessionUser(
+            id = 1,
+            username = "test",
+            role = Role.USER
+        )
+
+        val session = MockHttpSession().apply {
+            setAttribute("loginUser", sessionUser)
+        }
+
+        // 서비스가 false 반환 (== 좋아요 취소됨)
+        given(likeService.toggleLike(1L, likeRequest)).willReturn(false)
+
+        // when & then
+        mockMvc.perform(
+            post("/user/like")
+                .session(session)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"performanceId": 1}""")
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().string("Unliked"))
+    }
+
+
+}

--- a/src/test/java/com/fifo/ticketing/domain/like/service/LikeServiceTest.kt
+++ b/src/test/java/com/fifo/ticketing/domain/like/service/LikeServiceTest.kt
@@ -12,12 +12,15 @@ import com.fifo.ticketing.domain.performance.repository.PerformanceRepository
 import com.fifo.ticketing.domain.user.entity.User
 import com.fifo.ticketing.domain.user.repository.UserRepository
 import com.fifo.ticketing.global.entity.File
+import com.fifo.ticketing.global.exception.ErrorCode
+import com.fifo.ticketing.global.exception.ErrorException
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
 import java.util.*
 
@@ -152,5 +155,22 @@ class LikeServiceTest {
         assertThat(result).isTrue()
         assertThat(existingLike.isLiked).isTrue()
         assertThat(mockLikeCount.likeCount).isEqualTo(2L)
+    }
+
+
+    @Test
+    fun `존재하지 않는 공연일 경우 ErrorException 발생`() {
+        // given
+        val request = LikeRequest(performanceId)
+
+        every { userRepository.findById(userId) } returns Optional.of(mockUser)
+        every { performanceRepository.findById(performanceId) } returns Optional.empty()
+
+        // when & then
+        val exception = assertThrows<ErrorException> {
+            likeService.toggleLike(userId, request)
+        }
+
+        assertThat(exception.errorCode).isEqualTo(ErrorCode.NOT_FOUND_PERFORMANCES)
     }
 }


### PR DESCRIPTION

[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

UserLikeController 테스트 코드 작성
LikeServiceTest.kt 에러 코드 추가
#### 1. (작업 파일)

LikeCount.kt
UserLikeControllerTest.kt
LikeServiceTest.kt
(작업한 부분 설명 및 코드와 이미지 첨부)


<br/>

## 💬 리뷰
val session = MockHttpSession().apply {
    setAttribute("loginUser", sessionUser)
}

mockMvc.perform(
    post("/user/like")
        .session(session)
        .with(csrf())
        .contentType(MediaType.APPLICATION_JSON)
        .content("""{"performanceId": 1}""")
)

테스트에서 loginUser 세션을 주입했음에도 403 Forbidden 오류가 발생했습니다.
원인을 찾아보니, Spring Security는 세션과 별도로 동작하며, CSRF 토큰이 없을 경우 요청을 차단한다는 점을 알게 되었습니다.
그래서 .with(csrf())를 추가하여 CSRF 보호를 우회하도록 설정해 해결했습니다.
- (리뷰 받고 싶거나 알리고 싶은 내용)
: BaseDateEntity() 도 추가했습니다.
<br/>
