### PR TITLE
[fix] 좌석이 매진되고 취소됨에 따라 공연 예매 가능 여부를 바꾸는 메서드 추가

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.kt
+++ b/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.kt
@@ -1,7 +1,6 @@
 package com.fifo.ticketing.domain.performance.repository
 
 import com.fifo.ticketing.domain.performance.dto.AdminPerformanceBookDetailDto
-import com.fifo.ticketing.domain.performance.dto.AdminPerformanceStaticsDto
 import com.fifo.ticketing.domain.performance.entity.Category
 import com.fifo.ticketing.domain.performance.entity.Performance
 import org.springframework.data.domain.Page
@@ -13,7 +12,6 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
-import java.util.*
 
 @Repository
 interface PerformanceRepository : JpaRepository<Performance, Long> {
@@ -109,4 +107,30 @@ interface PerformanceRepository : JpaRepository<Performance, Long> {
                 "WHERE p.reservationStartTime <= :now AND p.performanceStatus = false ")
     )
     fun updatePerformanceStatusToReservationStart(@Param("now") now: LocalDateTime)
+
+    @Query(
+        """
+        SELECT p FROM Performance p 
+        WHERE p.deletedFlag = false AND p.startTime > :now
+        """
+    )
+    fun findActivePerformances(@Param("now") now: LocalDateTime): List<Performance>
+
+    @Modifying
+    @Query(
+        """
+        UPDATE Performance p 
+        SET p.performanceStatus = false
+        WHERE p.id = :id
+        """)
+    fun updatePerformanceStatusReservationUnavailable(id: Long)
+
+    @Modifying
+    @Query(
+        """
+        UPDATE Performance p 
+        SET p.performanceStatus = true
+        WHERE p.id = :id
+        """)
+    fun updatePerformanceStatusReservationAvailable(id: Long)
 }

--- a/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceReservationOpenService.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceReservationOpenService.java
@@ -1,6 +1,7 @@
 package com.fifo.ticketing.domain.performance.service;
 
 import com.fifo.ticketing.domain.performance.repository.PerformanceRepository;
+import com.fifo.ticketing.domain.seat.repository.SeatRepository;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,10 +12,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class PerformanceReservationOpenService {
 
     private final PerformanceRepository performanceRepository;
+    private final SeatRepository seatRepository;
 
     @Transactional
     public void updateStatusIfReservationStart() {
         performanceRepository.updatePerformanceStatusToReservationStart(LocalDateTime.now());
     }
 
+    @Transactional
+    public void updateStatusIfSoldOutOrCanceled() {
+        performanceRepository.findActivePerformances((LocalDateTime.now())).forEach(performance -> {
+            Long performanceId = performance.getId();
+            int availableSeats = seatRepository.countAvailableSeatsByPerformanceId(performanceId);
+
+            if (availableSeats == 0) {
+                performanceRepository.updatePerformanceStatusReservationUnavailable(performanceId);
+            } else if (availableSeats > 0) {
+                performanceRepository.updatePerformanceStatusReservationAvailable(performanceId);
+            }
+        });
+    }
 }

--- a/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceReservationSystemService.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceReservationSystemService.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class PerformanceReservationOpenService {
+public class PerformanceReservationSystemService {
 
     private final PerformanceRepository performanceRepository;
     private final SeatRepository seatRepository;

--- a/src/main/java/com/fifo/ticketing/global/scheduler/NotificationScheduler.kt
+++ b/src/main/java/com/fifo/ticketing/global/scheduler/NotificationScheduler.kt
@@ -26,4 +26,9 @@ class NotificationScheduler(
     fun updatePerformanceStatus() {
         performanceReservationOpenService.updateStatusIfReservationStart()
     }
+
+    @Scheduled(cron = "0 */10 * * * *")
+    fun updatePerformanceStatusIfSoldOutOrCanceled() {
+        performanceReservationOpenService.updateStatusIfSoldOutOrCanceled()
+    }
 }

--- a/src/main/java/com/fifo/ticketing/global/scheduler/SystemScheduler.kt
+++ b/src/main/java/com/fifo/ticketing/global/scheduler/SystemScheduler.kt
@@ -1,16 +1,15 @@
 package com.fifo.ticketing.global.scheduler
 
 import com.fifo.ticketing.domain.like.service.LikeMailNotificationService
-import com.fifo.ticketing.domain.performance.service.PerformanceReservationOpenService
+import com.fifo.ticketing.domain.performance.service.PerformanceReservationSystemService
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 
 @Component
-
-class NotificationScheduler(
+class SystemScheduler(
     private val likeMailNotificationService: LikeMailNotificationService,
-    private val performanceReservationOpenService: PerformanceReservationOpenService
+    private val performanceReservationSystemService: PerformanceReservationSystemService
 ) {
     @Scheduled(cron = "0 30 12 * * *")
     fun likeMailNotification() {
@@ -24,11 +23,11 @@ class NotificationScheduler(
 
     @Scheduled(cron = "0 0 13 * * *")
     fun updatePerformanceStatus() {
-        performanceReservationOpenService.updateStatusIfReservationStart()
+        performanceReservationSystemService.updateStatusIfReservationStart()
     }
 
     @Scheduled(cron = "0 */10 * * * *")
     fun updatePerformanceStatusIfSoldOutOrCanceled() {
-        performanceReservationOpenService.updateStatusIfSoldOutOrCanceled()
+        performanceReservationSystemService.updateStatusIfSoldOutOrCanceled()
     }
 }


### PR DESCRIPTION
## ✨ 설명
- #81 

#### 1. (작업 파일)
- src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.kt
- src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceReservationOpenService.java
- src/main/java/com/fifo/ticketing/global/scheduler/NotificationScheduler.kt

#### 2. (작업 내용 요약)
```java
    @Transactional
    public void updateStatusIfSoldOutOrCanceled() {
        performanceRepository.findActivePerformances((LocalDateTime.now())).forEach(performance -> {
            Long performanceId = performance.getId();
            int availableSeats = seatRepository.countAvailableSeatsByPerformanceId(performanceId);

            if (availableSeats == 0) {
                performanceRepository.updatePerformanceStatusReservationUnavailable(performanceId);
            } else if (availableSeats > 0) {
                performanceRepository.updatePerformanceStatusReservationAvailable(performanceId);
            }
        });
    }
```
예매 완료 후 10분동안 결제가 되지 않으면 좌석 예매가 취소되는 것을 참고해서, 10분마다 공연의 매진이나 좌석 취소 여부를 판단해서 공연 예매 가능 여부(performanceStatus)를 바꾸는 로직을 추가했습니다.
<br/>

## 💬 리뷰
- 기존에 updateStatusIfReservationStart 메서드만 존재하던 PerformanceReservationOpenService에 새로운 메서드가 추가되었기 때문에 클래스 이름의 변경을 생각하고 있습니다.
- 또한 NotificationScheduler이라는 이름도 알림을 보내는 용도 이외에도 스케줄링 메서드가 포함되었기 때문에 SystemScheduler 같은 이름으로 변경할 예정입니다.

<br/>
