### PR TITLE
[feat] : 버추얼 스레드 추가 , 이벤트 리스너 테스트 추가

### DIFF
--- a/src/main/java/com/fifo/ticketing/global/config/AsyncConfig.kt
+++ b/src/main/java/com/fifo/ticketing/global/config/AsyncConfig.kt
@@ -4,9 +4,8 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.AsyncConfigurer
 import org.springframework.scheduling.annotation.EnableAsync
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
-import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.Executors
 
 @EnableAsync
 @Configuration
@@ -14,22 +13,9 @@ class AsyncConfig : AsyncConfigurer {
 
     @Bean(name = ["mailExecutor"])
     override fun getAsyncExecutor(): Executor =
-        ThreadPoolTaskExecutor().apply {
-            corePoolSize = 200
-            maxPoolSize = 400
-            queueCapacity = 100
-            initialize()
-        }
+        Executors.newVirtualThreadPerTaskExecutor()
 
     @Bean(name = ["cancelPerformanceMailExecutor"])
     fun cancelMailExecutor(): Executor =
-        ThreadPoolTaskExecutor().apply {
-            corePoolSize = 200
-            maxPoolSize = 400
-            queueCapacity = 100
-            keepAliveSeconds = 60
-            threadNamePrefix = "async-exec-mail-"
-            setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
-            initialize()
-        }
+        Executors.newVirtualThreadPerTaskExecutor()
 }

--- a/src/main/java/com/fifo/ticketing/global/event/LikeMailEventListener.kt
+++ b/src/main/java/com/fifo/ticketing/global/event/LikeMailEventListener.kt
@@ -3,6 +3,7 @@ package com.fifo.ticketing.global.event
 import com.fifo.ticketing.domain.like.dto.NoPayedMailDto
 import com.fifo.ticketing.domain.like.dto.ReservationStartMailDto
 import com.fifo.ticketing.global.service.MailService
+import org.hibernate.query.sqm.tree.SqmNode.log
 
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
@@ -16,6 +17,7 @@ class LikeMailEventListener(
     @Async("mailExecutor")
     @EventListener
     fun handleLikeMailEvent(dto: ReservationStartMailDto) {
+        log.info("📨 [${Thread.currentThread().name}] 예약 시작 알림 메일 전송 시작 - ${dto.email}")
         mailService.sendReservationStartNoticeMail(dto)
     }
 

--- a/src/main/java/com/fifo/ticketing/global/event/LikeMailEventListener.kt
+++ b/src/main/java/com/fifo/ticketing/global/event/LikeMailEventListener.kt
@@ -17,7 +17,7 @@ class LikeMailEventListener(
     @Async("mailExecutor")
     @EventListener
     fun handleLikeMailEvent(dto: ReservationStartMailDto) {
-        log.info("📨 [${Thread.currentThread().name}] 예약 시작 알림 메일 전송 시작 - ${dto.email}")
+        log.info("예약 시작 알림 메일 전송 시작 ")
         mailService.sendReservationStartNoticeMail(dto)
     }
 

--- a/src/test/java/com/fifo/ticketing/global/event/LikeMailEventListenerTest.kt
+++ b/src/test/java/com/fifo/ticketing/global/event/LikeMailEventListenerTest.kt
@@ -1,0 +1,57 @@
+import com.fifo.ticketing.TicketingApplication
+import com.fifo.ticketing.domain.like.dto.NoPayedMailDto
+import com.fifo.ticketing.domain.like.dto.ReservationStartMailDto
+import com.fifo.ticketing.global.service.MailService
+import org.awaitility.Awaitility.await
+import org.mockito.Mockito.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+
+@SpringBootTest(classes = [TicketingApplication::class])
+@ActiveProfiles("ci")
+class LikeMailEventListenerIntegrationTest {
+
+    @Autowired
+    private lateinit var eventPublisher: ApplicationEventPublisher
+
+    @MockitoBean
+    private lateinit var mailService: MailService
+
+    @Test
+    fun `예약 시작 알림 이벤트가 발행되면 리스너가 메일 전송을 호출한다`() {
+        val dto = ReservationStartMailDto(
+            username = "테스트유저",
+            email = "test@fifo.com",
+            performanceTitle = "공연 제목",
+            reservationStartTime = LocalDateTime.of(2025, 10, 1, 19, 0)
+        )
+
+        eventPublisher.publishEvent(dto)
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+            verify(mailService).sendReservationStartNoticeMail(dto)
+        }
+    }
+
+    @Test
+    fun `미결제 이벤트가 발행되면 리스너가 메일 전송을 호출한다`() {
+        val dto = NoPayedMailDto(
+            username = "테스트유저",
+            email = "test@fifo.com",
+            performanceTitle = "공연 제목",
+            availableSeats = 10
+        )
+
+        eventPublisher.publishEvent(dto)
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+            verify(mailService).sendNoPayedNoticeMail(dto)
+        }
+    }
+}


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

버추얼 스레드로 변경 후 예약 시작 알림 및 미결제 알림 메일 이벤트 리스너의 비동기 동작 테스트를 통합 테스트로 검증했습니다.



#### 1. (작업 파일)

AsyncConfig.kt
LikeMailEventListenerTest.kt
#### 2. (작업 내용 요약)

![image](https://github.com/user-attachments/assets/2ce9d7cf-3f41-4950-bd24-a52d52270c37)

@SpringBootTest(classes = [TicketingApplication::class]) 추가하여 SpringBoot 설정 클래스 명시 → IllegalStateException 해결

이벤트 리스너에 로그 추가 → 비동기 실행 여부 확인