### PR TITLE
[test] book E2E 테스트 

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/book/controller/view/BookController.kt
+++ b/src/main/java/com/fifo/ticketing/domain/book/controller/view/BookController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import org.springframework.web.servlet.view.RedirectView
 
 @Controller
-@RequiredArgsConstructor
 @RequestMapping("/performances/{performanceId}/book")
 class BookController(
     private val bookService: BookService,

--- a/src/main/java/com/fifo/ticketing/domain/book/service/BookScheduleManager.kt
+++ b/src/main/java/com/fifo/ticketing/domain/book/service/BookScheduleManager.kt
@@ -35,12 +35,9 @@ class BookScheduleManager(
 
     @Transactional
     suspend fun scheduleCancelTask(bookId: Long, runTime: LocalDateTime) {
+
         bookScheduleRepository.save(bookId.toBookScheduledTask(runTime))
 
-        log.info { "${bookId}번 예매 생성됨 | ${LocalDateTime.now()}" }
-
-
-        // 레포지토리에 작업이 저장되면 실행됨
         coroutineScope.launch {
             // 10분동안 대기했다가
             delay(600000)

--- a/src/main/java/com/fifo/ticketing/domain/performance/entity/Performance.kt
+++ b/src/main/java/com/fifo/ticketing/domain/performance/entity/Performance.kt
@@ -43,7 +43,7 @@ class Performance(
     var reservationStartTime: LocalDateTime,
 
     @Setter
-    @OneToOne(fetch = FetchType.EAGER, cascade = [CascadeType.PERSIST])
+    @OneToOne(fetch = FetchType.EAGER, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "file_id", foreignKey = ForeignKey(name = "fk_performance_to_file"))
     var file: File? = null,
 

--- a/src/test/java/com/fifo/ticketing/domain/book/controller/view/BookControllerTests.kt
+++ b/src/test/java/com/fifo/ticketing/domain/book/controller/view/BookControllerTests.kt
@@ -5,6 +5,7 @@ import com.fifo.ticketing.domain.book.dto.BookCreateRequest
 import com.fifo.ticketing.domain.book.service.BookService
 import com.fifo.ticketing.domain.user.dto.SessionUser
 import com.fifo.ticketing.domain.user.entity.Role
+import com.fifo.ticketing.domain.user.repository.UserRepository
 import com.fifo.ticketing.global.service.MailService
 import jakarta.servlet.http.HttpSession
 import kotlinx.coroutines.test.runTest
@@ -19,15 +20,21 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.returnResult
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class TestSessionController {
-    @PostMapping("/test-session")
-    fun setTestSession(session: HttpSession): ResponseEntity<Void> {
-        val mockUser = SessionUser(1L, "테스트", Role.USER)
-        session.setAttribute("loginUser", mockUser)
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    @PostMapping("/test-session/{id}")
+    fun setTestSession(@PathVariable id: Long, session: HttpSession): ResponseEntity<Void> {
+        val user = userRepository.findById(id).orElseThrow()
+
+        session.setAttribute("loginUser", SessionUser(user.id!!, user.username, user.role))
+
         return ResponseEntity.ok().build()
     }
 }
@@ -55,10 +62,11 @@ class BookControllerTests {
         val request = BookCreateRequest(seatIds)
 
         val sessionCookie = webTestClient.post()
-            .uri("/test-session")
+            .uri("/test-session/$userId")
             .exchange()
             .returnResult<Void>()
             .responseCookies["JSESSIONID"]?.first()
+
         `when`(bookService.createBook(performanceId, userId, request))
             .thenReturn(bookId)
 

--- a/src/test/java/com/fifo/ticketing/domain/book/controller/view/BookE2ETests.kt
+++ b/src/test/java/com/fifo/ticketing/domain/book/controller/view/BookE2ETests.kt
@@ -1,0 +1,200 @@
+package com.fifo.ticketing.domain.book.controller.view
+
+import com.fifo.ticketing.domain.book.entity.Book
+import com.fifo.ticketing.domain.book.entity.BookSeat
+import com.fifo.ticketing.domain.book.entity.BookStatus
+import com.fifo.ticketing.domain.book.mapper.toBookCompleteDto
+import com.fifo.ticketing.domain.book.repository.BookRepository
+import com.fifo.ticketing.domain.book.service.BookService
+import com.fifo.ticketing.domain.performance.entity.Category
+import com.fifo.ticketing.domain.performance.entity.Grade
+import com.fifo.ticketing.domain.performance.entity.Performance
+import com.fifo.ticketing.domain.performance.entity.Place
+import com.fifo.ticketing.domain.performance.repository.GradeRepository
+import com.fifo.ticketing.domain.performance.repository.PerformanceRepository
+import com.fifo.ticketing.domain.performance.repository.PlaceRepository
+import com.fifo.ticketing.domain.seat.entity.Seat
+import com.fifo.ticketing.domain.seat.entity.SeatStatus
+import com.fifo.ticketing.domain.seat.repository.SeatRepository
+import com.fifo.ticketing.domain.user.dto.SessionUser
+import com.fifo.ticketing.domain.user.entity.Role
+import com.fifo.ticketing.domain.user.entity.User
+import com.fifo.ticketing.domain.user.repository.UserRepository
+import com.fifo.ticketing.global.entity.File
+import com.fifo.ticketing.global.repository.FileRepository
+import com.fifo.ticketing.global.service.MailService
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("ci")
+class BookMockMvcTests {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var bookRepository: BookRepository
+
+    @MockitoBean
+    lateinit var bookService: BookService
+
+    @Autowired
+    lateinit var performanceRepository: PerformanceRepository
+
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    @Autowired
+    lateinit var seatRepository: SeatRepository
+
+    @Autowired
+    lateinit var gradeRepository: GradeRepository
+
+    @Autowired
+    lateinit var placeRepository: PlaceRepository
+
+    @Autowired
+    lateinit var fileRepository: FileRepository
+
+    @MockitoBean
+    lateinit var mailServiceMock: MailService
+
+    private lateinit var user: User
+    private lateinit var place: Place
+    private lateinit var file: File
+    private lateinit var performance: Performance
+    private lateinit var book: Book
+    private lateinit var grade: Grade
+    private lateinit var seat: Seat
+    private lateinit var bookSeat: BookSeat
+
+    var urlPrefix: String = ""
+
+    @BeforeEach
+    fun setUp() {
+        urlPrefix = "https://picsum.photos/200"
+
+        user = userRepository.saveAndFlush(
+            User(
+                email = "example@gmail.com",
+                password = "123",
+                username = "테스트",
+                provider = null,
+                role = Role.USER,
+                isBlocked = false
+            )
+        )
+
+
+        place = placeRepository.saveAndFlush(Place(null, "서울특별시 서초구 서초동 1307", "강남아트홀", 100))
+
+        file = fileRepository.saveAndFlush(File(null, "poster.jpg", "sample.jpg"))
+
+        performance = performanceRepository.saveAndFlush(
+            Performance(
+                null, "라따뚜이", "라따뚜이는 픽시의 영화입니다.", place,
+                LocalDateTime.of(2025, 6, 1, 19, 0),
+                LocalDateTime.of(2025, 6, 1, 21, 0),
+                Category.MOVIE,
+                false,
+                false,
+                LocalDateTime.of(2025, 5, 12, 19, 0),
+                file
+            )
+        )
+
+        grade = gradeRepository.saveAndFlush(Grade(null, place, "A", 5000, 10))
+
+
+        book = bookRepository.saveAndFlush(
+            Book(
+                id = null,
+                performance = performance,
+                user = user,
+                totalPrice = 20000,
+                quantity = 2,
+                bookStatus = BookStatus.CONFIRMED
+            )
+        )
+
+        seat = seatRepository.saveAndFlush(
+            Seat(
+                null,
+                performance,
+                "A1",
+                5000,
+                grade,
+                SeatStatus.AVAILABLE
+            )
+        )
+
+        bookSeat = BookSeat(
+            id = null,
+            book = book,
+            seat = seat,
+        )
+
+    }
+
+    @Test
+    @Transactional
+    fun `예매 결제 완료 후 리다이렉트 및 메일 전송`() {
+
+        mockMvc.perform(
+            post("/performances/${performance.id}/book/complete/${book.id}/paid")
+        )
+            .andExpect(status().is3xxRedirection)
+            .andExpect(redirectedUrl("/performances/${performance.id}/book/complete/${book.id}?paid=true"))
+            .andReturn()
+
+        val updatedBook = book.id?.let { bookRepository.findById(it).get() }
+        updatedBook!!.bookStatus shouldBe BookStatus.PAYED
+
+        verify(mailServiceMock).sendBookInformationNoticeMail(any())
+    }
+
+    @Test
+    @WithMockUser(username = "testUser", roles = ["USER"])
+    fun `예매 완료 화면 진입시 정보가 담긴 모델이 전달된다`() {
+
+        val bookCompleteInfo = book.toBookCompleteDto(urlPrefix)
+
+        `when`(book.id?.let { bookService.getBookCompleteInfo(it) }).thenReturn(bookCompleteInfo)
+
+        val session = MockHttpSession()
+        session.setAttribute("loginUser", SessionUser(user.id!!, user.username, user.role))
+
+        mockMvc.perform(
+            get("/performances/${performance.id}/book/complete/${book.id}")
+                .param("paid", "true")
+                .session(session)
+        )
+            .andExpect(status().isOk)
+            .andExpect(view().name("book/complete"))
+            .andExpect(model().attribute("book", bookCompleteInfo))
+            .andExpect(model().attribute("bookId", book.id))
+
+        assertTrue(bookCompleteInfo.paymentCompleted)
+        book.id?.let { verify(bookService).getBookCompleteInfo(it) }
+    }
+}

--- a/src/test/java/com/fifo/ticketing/domain/book/controller/view/BookE2ETests.kt
+++ b/src/test/java/com/fifo/ticketing/domain/book/controller/view/BookE2ETests.kt
@@ -37,6 +37,7 @@ import org.springframework.mock.web.MockHttpSession
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.util.ReflectionTestUtils
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
@@ -55,14 +56,15 @@ class BookMockMvcTests {
     @Autowired
     lateinit var bookRepository: BookRepository
 
-    @MockitoBean
-    lateinit var bookService: BookService
 
     @Autowired
     lateinit var performanceRepository: PerformanceRepository
 
     @Autowired
     lateinit var userRepository: UserRepository
+
+    @Autowired
+    lateinit var bookService: BookService
 
     @Autowired
     lateinit var seatRepository: SeatRepository
@@ -79,6 +81,8 @@ class BookMockMvcTests {
     @MockitoBean
     lateinit var mailServiceMock: MailService
 
+
+
     private lateinit var user: User
     private lateinit var place: Place
     private lateinit var file: File
@@ -93,6 +97,7 @@ class BookMockMvcTests {
     @BeforeEach
     fun setUp() {
         urlPrefix = "https://picsum.photos/200"
+        ReflectionTestUtils.setField(bookService, "urlPrefix", urlPrefix)
 
         user = userRepository.saveAndFlush(
             User(
@@ -107,7 +112,6 @@ class BookMockMvcTests {
 
 
         place = placeRepository.saveAndFlush(Place(null, "서울특별시 서초구 서초동 1307", "강남아트홀", 100))
-
         file = fileRepository.saveAndFlush(File(null, "poster.jpg", "sample.jpg"))
 
         performance = performanceRepository.saveAndFlush(
@@ -157,7 +161,6 @@ class BookMockMvcTests {
     }
 
     @Test
-    @Transactional
     fun `예매 결제 완료 후 리다이렉트 및 메일 전송`() {
 
         mockMvc.perform(
@@ -178,8 +181,7 @@ class BookMockMvcTests {
     fun `예매 완료 화면 진입시 정보가 담긴 모델이 전달된다`() {
 
         val bookCompleteInfo = book.toBookCompleteDto(urlPrefix)
-
-        `when`(book.id?.let { bookService.getBookCompleteInfo(it) }).thenReturn(bookCompleteInfo)
+        bookCompleteInfo.paymentCompleted = true
 
         val session = MockHttpSession()
         session.setAttribute("loginUser", SessionUser(user.id!!, user.username, user.role))
@@ -194,7 +196,5 @@ class BookMockMvcTests {
             .andExpect(model().attribute("book", bookCompleteInfo))
             .andExpect(model().attribute("bookId", book.id))
 
-        assertTrue(bookCompleteInfo.paymentCompleted)
-        book.id?.let { verify(bookService).getBookCompleteInfo(it) }
     }
 }

--- a/src/test/java/com/fifo/ticketing/domain/book/service/BookServiceTests.kt
+++ b/src/test/java/com/fifo/ticketing/domain/book/service/BookServiceTests.kt
@@ -147,7 +147,6 @@ class BookServiceTests {
             bookService.cancelBookByAdmin(bookId)
         }
 
-
         error.errorCode shouldBe ErrorCode.NOT_FOUND_BOOK
 
     }

--- a/src/test/java/com/fifo/ticketing/domain/performance/controller/api/PerformanceApiControllerKotlinTests.kt
+++ b/src/test/java/com/fifo/ticketing/domain/performance/controller/api/PerformanceApiControllerKotlinTests.kt
@@ -14,6 +14,7 @@ import com.fifo.ticketing.domain.seat.repository.SeatRepository
 import com.fifo.ticketing.global.entity.File
 import com.fifo.ticketing.global.exception.ErrorCode
 import com.fifo.ticketing.global.exception.ErrorException
+import com.fifo.ticketing.global.repository.FileRepository
 import com.fifo.ticketing.global.service.ImageFileService
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
@@ -65,6 +66,9 @@ class PerformanceApiControllerKotlinTests {
     private lateinit var seatRepository: SeatRepository
 
     @Autowired
+    private lateinit var fileRepository: FileRepository
+
+    @Autowired
     private lateinit var entityManager: EntityManager
 
     @MockitoBean
@@ -85,15 +89,15 @@ class PerformanceApiControllerKotlinTests {
         val gradeS = Grade(null, place, "S", 120000, 20)
         val gradeA = Grade(null, place, "A", 90000, 30)
 
-        mockFile = File(null, "poster.jpg", "sample.jpg")
+        mockFile = fileRepository.save(File(null, "poster.jpg", "sample.jpg"))
 
         gradeRepository.saveAll(listOf(gradeS, gradeA))
         whenever(imageFileService.uploadFile(any())).thenReturn(
-            File(
+            fileRepository.save(File(
                 null,
                 "encoded.webp",
                 "test.webp"
-            )
+            ))
         )
     }
 
@@ -200,11 +204,11 @@ class PerformanceApiControllerKotlinTests {
         )
 
         whenever(imageFileService.uploadFile(any())).thenReturn(
-            File(
+            fileRepository.save(File(
                 null,
                 "encoded.webp",
-                "default.webp"
-            )
+                "test.webp"
+            ))
         )
 
         mockMvc.perform(


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#74 

#### 1. (작업 파일)

- src/test/java/com/fifo/ticketing/domain/book/controller/view/BookControllerTests.kt
- src/test/java/com/fifo/ticketing/domain/book/controller/view/BookE2ETests.kt

#### 2. (작업 내용 요약)

```kotlin
        file = fileRepository.saveAndFlush(File(null, "poster.jpg", "sample.jpg"))

        performance = performanceRepository.saveAndFlush(
            Performance(
                null, "라따뚜이", "라따뚜이는 픽시의 영화입니다.", place,
                LocalDateTime.of(2025, 6, 1, 19, 0),
                LocalDateTime.of(2025, 6, 1, 21, 0),
                Category.MOVIE,
                false,
                false,
                LocalDateTime.of(2025, 5, 12, 19, 0),
                file
            )
        )
```
실제 db와 연결하여 테스트를 진행해야 하기 때문에 beforeEach에서 위처럼 `saveAndFlush()`로 저장하였습니다.
그런데 기존 performance의 file 필드가  CascadeType.PERSIST 설정이 되어있었어서 detached 에러가 계속 발생하였습니다.

그래서 performance의 file 필드를 CascadeType.PERSIST가 아닌 CascadeType.MERGE로 바꾸어서 해결하였습니다.

<br/>

suspend 컨트롤러도 어제부터 계속 테스트 시도를 해보았으나.. 잘 되지 않습니다 ㅜㅜ
mockMvc는 코루틴을 지원하지 않아서 WebFlux기반의 WebTestClient를 사용해야 합니다.

WebTestClient는 mockMvc와 달리 아래처럼 세션을 수동으로 설정해주어야 합니다.

```kotlin

    val sessionCookie = webTestClient.post()
        .uri("/test-session")
        .exchange()
        .returnResult<Void>()
        .responseCookies["JSESSIONID"]?.first()

    val response = webTestClient.post()
        .uri("/performances/$performanceId/book?seatIds=1")
        .cookie("JSESSIONID", sessionCookie?.value ?: "dummy")
        .exchange()
        .expectStatus().is3xxRedirection

```

하지만 계속 로그인이 실패해서 테스트 진행이 되지 않습니다.

일단 작업 된 부분 먼저 pr 올리고 마저 해결해보도록 하겠습니다


<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->




<br/>
